### PR TITLE
fix of infinite ammo

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ end)
 CreateThread(function()
     while true do
         local ped = PlayerPedId()
-        if IsPedShooting(ped) and (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then          --Change
+        if IsPedArmed(ped, 7) == 1 and (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) or IsPedShooting(ped) and (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
             local weapon = GetSelectedPedWeapon(ped)
             local ammo = GetAmmoInPedWeapon(ped, weapon)
             TriggerServerEvent("weapons:server:UpdateWeaponAmmo", CurrentWeaponData, tonumber(ammo))


### PR DESCRIPTION
This correction in the qb-weapons code to avoid the bug that when shooting does not save the correct number of ammunition and at the same time the gallon of fuel works, reported in the issue #https://github.com/Sna-aaa/qb-sna-fuel/issues/8